### PR TITLE
Vector indexers

### DIFF
--- a/ShaderTK/vec2.cs
+++ b/ShaderTK/vec2.cs
@@ -46,7 +46,7 @@ namespace ShaderTK
                         case 1:
                             return y;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
                 set
@@ -60,7 +60,7 @@ namespace ShaderTK
                             y = value;
                             return;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
             }

--- a/ShaderTK/vec2.cs
+++ b/ShaderTK/vec2.cs
@@ -35,6 +35,36 @@ namespace ShaderTK
                 this.y = y;
             }
 
+            public float this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return x;
+                        case 1:
+                            return y;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                set
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            x = value;
+                            return;
+                        case 1:
+                            y = value;
+                            return;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+
             public static vec2 operator +(vec2 l, vec2 r)
             {
                 throw new NotImplementedException();

--- a/ShaderTK/vec3.cs
+++ b/ShaderTK/vec3.cs
@@ -28,6 +28,41 @@ namespace ShaderTK
         protected partial struct vec3
         {
             public float x, y, z;
+
+            public float this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return x;
+                        case 1:
+                            return y;
+                        case 2:
+                            return z;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                set
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            x = value;
+                            return;
+                        case 1:
+                            y = value;
+                            return;
+                        case 2:
+                            z = value;
+                            return;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
         }
     }
 }

--- a/ShaderTK/vec3.cs
+++ b/ShaderTK/vec3.cs
@@ -42,7 +42,7 @@ namespace ShaderTK
                         case 2:
                             return z;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
                 set
@@ -59,7 +59,7 @@ namespace ShaderTK
                             z = value;
                             return;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
             }

--- a/ShaderTK/vec4.cs
+++ b/ShaderTK/vec4.cs
@@ -54,7 +54,7 @@ namespace ShaderTK
                         case 3:
                             return w;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
                 set
@@ -74,7 +74,7 @@ namespace ShaderTK
                             w = value;
                             return;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new IndexOutOfRangeException();
                     }
                 }
             }

--- a/ShaderTK/vec4.cs
+++ b/ShaderTK/vec4.cs
@@ -39,6 +39,46 @@ namespace ShaderTK
                 throw new NotImplementedException();
             }
 
+            public float this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return x;
+                        case 1:
+                            return y;
+                        case 2:
+                            return z;
+                        case 3:
+                            return w;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                set
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            x = value;
+                            return;
+                        case 1:
+                            y = value;
+                            return;
+                        case 2:
+                            z = value;
+                            return;
+                        case 3:
+                            w = value;
+                            return;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+
             public static vec4 operator *(vec4 l, vec4 r)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Impliments of vector indexer.  

In GLSL, costant value index is checked on compile time.(ex. value[3] on vec2 is not allowed)
